### PR TITLE
Side-scrolling tables instead of collapsible tables

### DIFF
--- a/src/scss/elements/_lists.scss
+++ b/src/scss/elements/_lists.scss
@@ -6,10 +6,6 @@ ol {
   &.with-bullets {
     list-style-type: disc;
     padding-left: vars.$space-lg;
-
-    @include mixins.mobile {
-      padding-left: vars.$space-md;
-    }
   }
 }
 

--- a/src/scss/elements/_tables.scss
+++ b/src/scss/elements/_tables.scss
@@ -1,7 +1,11 @@
 @use '../vars';
 @use '../mixins';
 
-.data-table {
+main {
+  overflow-x: auto;
+}
+
+.zzz-data-table {
   margin-bottom: vars.$space-xxl;
 
   .data-table__title {
@@ -156,7 +160,7 @@
   }
 }
 
-.data-table.predictions:not(.predictions--has-details) {
+.table.predictions:not(.predictions--has-details) {
   width: 65%;
 
   thead > tr > th {
@@ -175,5 +179,124 @@
     &:nth-of-type(2) {
       width: 30%;
     }
+  }
+}
+
+/* Standard Tables */
+.data-table {
+  margin-bottom: vars.$space-xxl;
+
+  table {
+    border-collapse: collapse;
+    width: 100%;
+    white-space: nowrap;
+
+    td,
+    th {
+      border-bottom: transparent solid 1px;
+      text-align: left;
+      padding: vars.$space-sm vars.$space-sm vars.$space-sm vars.$space-lg;
+
+      &:first-of-type {
+        padding-left: 0;
+      }
+
+      @include mixins.mobile {
+        border-bottom: #eee solid 1px;
+      }
+    }
+
+    tr {
+      &:hover {
+        background: rgba(180, 180, 180, 0.15);
+      }
+
+      &[onclick]:hover {
+        cursor: pointer;
+
+        a {
+          color: vars.$color-focus;
+          text-decoration: underline;
+        }
+      }
+
+      &[onclick]:focus-within {
+        outline: 1.5px dotted black;
+        outline-offset: 2px;
+        background: rgba(180, 180, 180, 0.1);
+      }
+
+      &[onclick] > th > a:focus {
+        outline: none;
+      }
+    }
+
+    thead.visible {
+      tr:hover {
+        background-color: transparent;
+      }
+
+      th {
+        border-bottom: 1.5px solid black;
+      }
+
+      th:nth-of-type(2) {
+        padding-left: 0;
+      }
+
+      + tbody th {
+        font-weight: 400;
+      }
+
+      @include mixins.mobile {
+        th {
+          border-top: 1.5px solid black;
+        }
+      }
+    }
+
+    tbody {
+      &:hover {
+        td,
+        th {
+          border-bottom: #eee solid 1px;
+        }
+      }
+
+      tr:last-of-type {
+        th,
+        td {
+          border-bottom: 1.5px solid black;
+        }
+      }
+    }
+  }
+
+  caption {
+    text-align: left;
+    font-style: italic;
+    padding: 0.25em 0.5em 0.5em 0.5em;
+  }
+
+  &[role='region'][aria-labelledby][tabindex] {
+    overflow: auto;
+  }
+
+  &[role='region'][aria-labelledby][tabindex]:focus {
+    outline: 2px dotted black;
+    outline-offset: -2px;
+  }
+
+  /* shadow */
+  &[role='region'][aria-labelledby][tabindex] {
+    background: linear-gradient(to right, #fff 30%, rgba(255, 255, 255, 0)),
+      linear-gradient(to right, rgba(255, 255, 255, 0), #fff 70%) 0 100%,
+      radial-gradient(farthest-side at 0% 50%, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0)),
+      radial-gradient(farthest-side at 100% 50%, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0)) 0 100%;
+    background-repeat: no-repeat;
+    background-color: #fff;
+    background-size: 40px 100%, 40px 100%, 14px 100%, 14px 100%;
+    background-position: 0 0, 100%, 0 0, 100%;
+    background-attachment: local, local, scroll, scroll;
   }
 }

--- a/src/scss/elements/_tables.scss
+++ b/src/scss/elements/_tables.scss
@@ -5,163 +5,8 @@
   overflow-x: auto;
 }
 
-.zzz-data-table {
-  margin-bottom: vars.$space-xxl;
-
-  .data-table__title {
-    margin: 0;
-    font-size: 1.953rem;
-  }
-
-  caption {
-    text-align: left;
-
-    p {
-      margin-bottom: vars.$space-xs;
-    }
-  }
-
-  .data-table__table {
-    width: 100%;
-    table-layout: fixed;
-    border-collapse: collapse;
-
-    * {
-      outline: 0;
-    }
-
-    thead:not(.visible) {
-      @include mixins.visually-hidden;
-
-      + tbody th {
-        font-weight: 600;
-      }
-
-      + tbody tr:first-of-type {
-        th,
-        td {
-          border-top: 1.5px solid black;
-        }
-      }
-    }
-
-    th {
-      text-align: left;
-    }
-
-    thead.visible {
-      th {
-        border-bottom: 1.5px solid black;
-      }
-
-      + tbody th {
-        font-weight: 400;
-      }
-    }
-
-    tbody {
-      tr {
-        td,
-        th {
-          border-bottom: transparent solid 1px;
-        }
-      }
-
-      &:hover {
-        td,
-        th {
-          border-bottom: #eee solid 1px;
-        }
-      }
-
-      tr:hover {
-        background: #f5f5f5;
-      }
-
-      tr[onclick]:hover {
-        cursor: pointer;
-
-        a {
-          color: vars.$color-focus;
-          text-decoration: underline;
-        }
-      }
-
-      tr[onclick]:focus-within {
-        outline: 2px dotted black;
-        outline-offset: 2px;
-        background: #fbfbfb;
-      }
-
-      td {
-        text-align: left;
-        padding-left: 0;
-      }
-    }
-  }
-
-  /* For mobile: https://www.accessibility-developer-guide.com/examples/tables/responsive/ */
-  @include mixins.mobile {
-    .data-table__table {
-      display: block;
-
-      caption,
-      tr,
-      tbody,
-      th,
-      td {
-        display: block;
-      }
-
-      thead {
-        @include mixins.visually-hidden;
-      }
-
-      .data-table__table thead.visible + tbody th {
-        font-weight: 600;
-      }
-
-      tbody tr {
-        padding-bottom: vars.$space-lg;
-
-        &:last-of-type {
-          border-bottom: 1.5px solid black;
-        }
-
-        th {
-          border-top: 1.5px solid black;
-          border-bottom: 1px dotted black;
-        }
-
-        td {
-          margin-left: vars.$space-md;
-        }
-      }
-
-      .narrow-th {
-        font-weight: 400;
-        width: 45%;
-        display: inline-block;
-      }
-    }
-  }
-
-  @include mixins.tablet {
-    .data-table__table tbody tr:last-of-type {
-      th,
-      td {
-        border-bottom: 1.5px solid black;
-      }
-    }
-
-    .narrow-th {
-      display: none;
-    }
-  }
-}
-
-.table.predictions:not(.predictions--has-details) {
-  width: 65%;
+.data-table.predictions:not(.predictions--has-details) {
+  max-width: 850px;
 
   thead > tr > th {
     &:nth-of-type(1) {
@@ -194,10 +39,6 @@
   caption {
     text-align: left;
     margin-bottom: vars.$space-xs;
-
-    // p {
-    //   margin-bottom: vars.$space-xs;
-    // }
   }
 
   table {
@@ -213,7 +54,7 @@
     th {
       border-bottom: transparent solid 1px;
       text-align: left;
-      padding: vars.$space-sm vars.$space-sm vars.$space-sm vars.$space-lg;
+      padding: vars.$space-sm;
 
       @include mixins.mobile {
         border-bottom: #eee solid 1px;

--- a/src/scss/elements/_tables.scss
+++ b/src/scss/elements/_tables.scss
@@ -1,7 +1,7 @@
 @use '../vars';
 @use '../mixins';
 
-main {
+.overflow-x {
   overflow-x: auto;
 }
 
@@ -186,10 +186,28 @@ main {
 .data-table {
   margin-bottom: vars.$space-xxl;
 
+  .data-table__title {
+    margin: 0;
+    font-size: 1.953rem;
+  }
+
+  caption {
+    text-align: left;
+    margin-bottom: vars.$space-xs;
+
+    // p {
+    //   margin-bottom: vars.$space-xs;
+    // }
+  }
+
   table {
     border-collapse: collapse;
     width: 100%;
     white-space: nowrap;
+
+    &.data-table__table--with-line-breaks {
+      white-space: initial;
+    }
 
     td,
     th {
@@ -197,12 +215,12 @@ main {
       text-align: left;
       padding: vars.$space-sm vars.$space-sm vars.$space-sm vars.$space-lg;
 
-      &:first-of-type {
-        padding-left: 0;
-      }
-
       @include mixins.mobile {
         border-bottom: #eee solid 1px;
+
+        &:first-of-type {
+          padding-left: vars.$space-xs;
+        }
       }
     }
 
@@ -240,16 +258,27 @@ main {
         border-bottom: 1.5px solid black;
       }
 
-      th:nth-of-type(2) {
-        padding-left: 0;
-      }
-
       + tbody th {
         font-weight: 400;
       }
 
       @include mixins.mobile {
         th {
+          border-top: 1.5px solid black;
+        }
+      }
+    }
+
+    thead:not(.visible) {
+      @include mixins.visually-hidden;
+
+      + tbody th {
+        font-weight: 600;
+      }
+
+      + tbody tr:first-of-type {
+        th,
+        td {
           border-top: 1.5px solid black;
         }
       }
@@ -270,12 +299,6 @@ main {
         }
       }
     }
-  }
-
-  caption {
-    text-align: left;
-    font-style: italic;
-    padding: 0.25em 0.5em 0.5em 0.5em;
   }
 
   &[role='region'][aria-labelledby][tabindex] {

--- a/src/scss/elements/_tables.scss
+++ b/src/scss/elements/_tables.scss
@@ -101,7 +101,11 @@
     .data-table__table {
       display: block;
 
-      caption, tr, tbody, th, td {
+      caption,
+      tr,
+      tbody,
+      th,
+      td {
         display: block;
       }
 
@@ -139,7 +143,6 @@
   }
 
   @include mixins.tablet {
-
     .data-table__table tbody tr:last-of-type {
       th,
       td {

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -39,3 +39,9 @@ img {
   max-width: 100%;
   height: auto;
 }
+
+@include mixins.mobile-xs {
+  .hidden--mobile-xs {
+    display: none;
+  }
+}

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -27,10 +27,6 @@
 @use './elements/_lists';
 @use './elements/_tables';
 
-// * {
-//   outline: 1px solid grey;
-// }
-
 .visually-hidden {
   @include mixins.visually-hidden;
 }

--- a/src/views/groundhog.njk
+++ b/src/views/groundhog.njk
@@ -60,7 +60,7 @@
     </div>
 
     <div class="predictions overflow-x">
-      <div class="recent-predictions data-table" role="region" aria-labelledby="data-table--recent-predictions" tabindex="0">
+      <div class="recent-predictions data-table" role="region" aria-labelledby="data-table--recent-predictions">
         <table class="data-table__table">
           <caption id="data-table--recent-predictions">
             <h2 class="data-table__title">Recent predictions</h2>

--- a/src/views/groundhog.njk
+++ b/src/views/groundhog.njk
@@ -59,16 +59,16 @@
       </div>
     </div>
 
-    <div class="predictions">
-      <div class="recent-predictions data-table">
+    <div class="predictions overflow-x">
+      <div class="recent-predictions data-table" role="region" aria-labelledby="data-table--recent-predictions" tabindex="0">
         <table class="data-table__table">
-          <caption>
+          <caption id="data-table--recent-predictions">
             <h2 class="data-table__title">Recent predictions</h2>
           </caption>
           <thead>
             <tr>
               <th>Year</th>
-              <th>Saw shadow?</th>
+              <th class="hidden--mobile-xs">Saw shadow?</th>
               <th>Prediction</th>
             </tr>
           </thead>
@@ -77,7 +77,7 @@
               {% if prediction.year >= 2018 %}
                 <tr>
                   <th>{{ prediction.year }}</th>
-                  <td>
+                  <td class="hidden--mobile-xs">
                     {% if prediction.shadow -%}
                       Yes, saw shadow.
                     {%- else -%}

--- a/src/views/groundhogs.njk
+++ b/src/views/groundhogs.njk
@@ -15,9 +15,9 @@
         <li><strong>{{ recentPredictions.spring }}</strong> groundhogs ({{ recentPredictions.percent.spring }}%) predicted an early spring: 🌷</li>
       </ul>
 
-      <div class="groundhogs data-table">
-        <table role="grid" class="data-table__table data-table__table">
-          <caption class="visually-hidden">
+      <div class="groundhogs data-table" role="region" aria-labelledby="data-table--groundhogs" tabindex="0">
+        <table role="grid" class="data-table__table">
+          <caption id="data-table--groundhogs" class="visually-hidden">
               <h2>All groundhogs</h2>
           </caption>
           <thead role="presentation" class="visible">
@@ -33,16 +33,26 @@
             {% for groundhog in groundhogs %}
               <tr role="row" onclick="window.location='/groundhogs/{{groundhog.id}}/';">
                 <th role="columnheader"><a href="/groundhogs/{{groundhog.id}}/" class="underline">{{ groundhog.name }}</a></th>
-                <td role="gridcell"><span aria-hidden="true" class="narrow-th">Region: </span>{{ groundhog.region }}</td>
-                <td role="gridcell"><span aria-hidden="true" class="narrow-th">Country: </span>{{ groundhog.country }}</td>
-                <td role="gridcell"><span aria-hidden="true" class="narrow-th">Current prediction: </span>
+                <td role="gridcell">
+                  {# <span aria-hidden="true" class="narrow-th">Region: </span> #}
+                  {{ groundhog.region }}
+                </td>
+                <td role="gridcell">
+                  {# <span aria-hidden="true" class="narrow-th">Country: </span> #}
+                  {{ groundhog.country }}
+                </td>
+                <td role="gridcell">
+                  {# <span aria-hidden="true" class="narrow-th">Current prediction: </span> #}
                   {% if groundhog.latestPrediction.shadow %}
                     <span role="img" aria-label="Longer winter">☃️</span>
                   {% else %}
                     <span role="img" aria-label="Early spring">🌷</span>
                   {% endif %}
                 </td>
-                <td role="gridcell"><span aria-hidden="true" class="narrow-th">Total predictions: </span>{{ groundhog.predictionsCount }}</td>
+                <td role="gridcell">
+                  {# <span aria-hidden="true" class="narrow-th">Total predictions: </span> #}
+                  {{ groundhog.predictionsCount }}
+                </td>
               </tr>
             {% endfor %}
           </tbody>

--- a/src/views/groundhogs.njk
+++ b/src/views/groundhogs.njk
@@ -34,15 +34,12 @@
               <tr role="row" onclick="window.location='/groundhogs/{{groundhog.id}}/';">
                 <th role="columnheader"><a href="/groundhogs/{{groundhog.id}}/" class="underline">{{ groundhog.name }}</a></th>
                 <td role="gridcell">
-                  {# <span aria-hidden="true" class="narrow-th">Region: </span> #}
                   {{ groundhog.region }}
                 </td>
                 <td role="gridcell">
-                  {# <span aria-hidden="true" class="narrow-th">Country: </span> #}
                   {{ groundhog.country }}
                 </td>
                 <td role="gridcell">
-                  {# <span aria-hidden="true" class="narrow-th">Current prediction: </span> #}
                   {% if groundhog.latestPrediction.shadow %}
                     <span role="img" aria-label="Longer winter">☃️</span>
                   {% else %}
@@ -50,7 +47,6 @@
                   {% endif %}
                 </td>
                 <td role="gridcell">
-                  {# <span aria-hidden="true" class="narrow-th">Total predictions: </span> #}
                   {{ groundhog.predictionsCount }}
                 </td>
               </tr>

--- a/src/views/groundhogs.njk
+++ b/src/views/groundhogs.njk
@@ -9,7 +9,7 @@
 
   <div class="inner-content">
     <div class="inner-content__main">
-      <p>In 2022:</p>
+      <p>There are <strong>{{ groundhogs | length }}</strong> weather-predicting groundhogs that made predictions in 2022.</p>
       <ul class="with-bullets">
         <li><strong>{{ recentPredictions.winter }}</strong> groundhogs ({{ recentPredictions.percent.winter }}%) predicted six more weeks of winter: ☃️</li>
         <li><strong>{{ recentPredictions.spring }}</strong> groundhogs ({{ recentPredictions.percent.spring }}%) predicted an early spring: 🌷</li>

--- a/src/views/index.njk
+++ b/src/views/index.njk
@@ -5,6 +5,6 @@
 {%- endblock %}
 
 {% block content %}
-  <h1 class="not-caps">GROUNDHOG-D<span class="letter-spacing--less">A</span>Y.com joins the ancient wisdom of <a class="underline" href="/groundhogs">groundhogs</a> with the entrepreneurial dynamism of <a href="/api" class="underline">structured data</a>.</h1>
+  <h1 class="not-caps">GROUNDHOG-D<span class="letter-spacing--less">A</span>Y.com binds the ancient wisdom of <a class="underline" href="/groundhogs">groundhogs</a> with the entrepreneurial dynamism of <a href="/api" class="underline">structured data</a>.</h1>
   <p class="h2 not-caps">Ready to swap forecasts for foresight? Check out <a href="#" class="underline">2022’s predictions</a>.</p>
 {% endblock %}

--- a/src/views/layout.njk
+++ b/src/views/layout.njk
@@ -42,7 +42,7 @@
       </div>
     </nav>
     {# <aside>Aside</aside> #}
-    <main>
+    <main class="overflow-x">
     {% block content %}{% endblock %}
     </main>
     <footer>

--- a/src/views/predictions.njk
+++ b/src/views/predictions.njk
@@ -23,7 +23,7 @@
       <p>This data <a href="#get-the-data" class="underline">can also be returned</a> as formatted JSON or as a CSV file.</p>
 
       {% set hasDetails = groundhog.predictions[0].details %}
-      <div class="data-table predictions {% if hasDetails%}predictions--has-details{% endif %}" role="region" aria-labelledby="data-table--predictions" tabindex="0">
+      <div class="data-table predictions {% if hasDetails%}predictions--has-details{% endif %}" role="region" aria-labelledby="data-table--predictions">
 
         <table class="data-table__table data-table__table--with-line-breaks">
           <caption id="data-table--predictions">

--- a/src/views/predictions.njk
+++ b/src/views/predictions.njk
@@ -23,9 +23,10 @@
       <p>This data <a href="#get-the-data" class="underline">can also be returned</a> as formatted JSON or as a CSV file.</p>
 
       {% set hasDetails = groundhog.predictions[0].details %}
-      <div class="data-table predictions {% if hasDetails%}predictions--has-details{% endif %}">
-        <table class="data-table__table">
-          <caption>
+      <div class="data-table predictions {% if hasDetails%}predictions--has-details{% endif %}" role="region" aria-labelledby="data-table--predictions" tabindex="0">
+
+        <table class="data-table__table data-table__table--with-line-breaks">
+          <caption id="data-table--predictions">
             <h2 class="data-table__title">All predictions</h2>
           </caption>
           <thead class="visible">
@@ -33,7 +34,7 @@
               <th>Year</th>
               <th>Saw shadow?</th>
               {% if hasDetails %}
-                <th>Details</th>
+                <th class="hidden--mobile-xs">Details</th>
               {% endif %}
             </tr>
           </thead>
@@ -52,7 +53,7 @@
                     {%- endif %}
                   </td>
                   {% if hasDetails -%}
-                      <td>{{ prediction.details }}</td>
+                      <td class="hidden--mobile-xs">{{ prediction.details }}</td>
                   {%- endif %}
                 </tr>
             {% endfor %}


### PR DESCRIPTION
Usually I wouldn't do a PR for this at this stage (not "live", only 1 contributor), but this is a fairly important change, probably worth documenting.

I had previously created all the tables so that they would collapse on mobile (see example here: https://www.accessibility-developer-guide.com/examples/tables/responsive/), but when actually using the site, it made pages too long and too busy. 

I wondered if scrollable tables would be better, so I did a quick comparison and showed Rhianna, and she made the point that the scrolling-table-based-format made it easier to compare across rows, whereas the "collapsible" format made it easier to see everything about one row. It also saves a ton of vertical space, which I think is a plus. Ultimately, I think these tables should also be sortable, but for now we can leave it. 

So this is a before/after, showing how the tables used to look on desktop and mobile, and then how they currently look. It's mostly CSS changes rather than markup, but maybe it will be useful to see how they were implemented before. I am anticipating a potential suggested redesign coming in anyway, so this might change again in a couple of days.

This redesign was inspired by "[under engineered responsive tables](https://adrianroselli.com/2020/11/under-engineered-responsive-tables.html)", and notably also adds more padding to the rows themselves. The smaller tables have disappearing columns, [which are in the earlier tutorial I linked to](https://www.accessibility-developer-guide.com/examples/tables/responsive/).

Sources: 
- https://www.accessibility-developer-guide.com/examples/tables/responsive/
- https://adrianroselli.com/2020/11/under-engineered-responsive-tables.html

## Screenshots

### All groundhogs

|         | before | after |
|---------|--------|-------|
| desktop |   <img width="1497" alt="Screen Shot 2022-06-14 at 14 25 44" src="https://user-images.githubusercontent.com/2454380/173591074-f570f4fc-b77c-44cb-83e3-40edb3833c3f.png">    |   <img width="1497" alt="Screen Shot 2022-06-14 at 14 25 42" src="https://user-images.githubusercontent.com/2454380/173591052-6095004e-07c2-438b-9d18-2aad48714288.png"> |
| mobile  |    <img width="657" alt="Screen Shot 2022-06-14 at 14 26 31" src="https://user-images.githubusercontent.com/2454380/173591091-d2db0ab5-1e0f-4292-ab2b-c70ee6d6aef2.png">    | <img width="657" alt="Screen Shot 2022-06-14 at 14 26 22" src="https://user-images.githubusercontent.com/2454380/173591084-0d31a67f-f3aa-44f1-98c7-a09a3f02a09e.png">   |


### Recent predictions

|         | before | after |
|---------|--------|-------|
| desktop |   <img width="1417" alt="Screen Shot 2022-06-14 at 14 29 05" src="https://user-images.githubusercontent.com/2454380/173592286-4fb02471-99cb-4868-802a-5c909cf4369a.png">    |  <img width="1417" alt="Screen Shot 2022-06-14 at 14 29 01" src="https://user-images.githubusercontent.com/2454380/173592261-4f130fb4-34da-451a-a0fa-28f36d6e3a59.png">   |
| mobile  |    <img width="562" alt="Screen Shot 2022-06-14 at 14 29 44" src="https://user-images.githubusercontent.com/2454380/173592295-aab27bed-fb51-4ef1-a393-15e378742278.png">   |  <img width="562" alt="Screen Shot 2022-06-14 at 14 29 38" src="https://user-images.githubusercontent.com/2454380/173592294-fbbd6fd5-7a80-45bf-b324-555889c15ee1.png">   |


### All predictions

|         | before | after |
|---------|--------|-------|
| desktop |   <img width="1539" alt="Screen Shot 2022-06-14 at 14 31 08" src="https://user-images.githubusercontent.com/2454380/173591757-30ab80dc-945e-41b7-9e7e-7a116f6299d4.png">    |    <img width="1539" alt="Screen Shot 2022-06-14 at 14 31 05" src="https://user-images.githubusercontent.com/2454380/173591749-dd8542f5-b0cb-4dda-9a20-1a771c677f5e.png">   |
| mobile  |   <img width="562" alt="Screen Shot 2022-06-14 at 14 30 29" src="https://user-images.githubusercontent.com/2454380/173591870-6ab3c85c-28ec-4f16-9bdb-0dbb166bfe4f.png">    |   <img width="562" alt="Screen Shot 2022-06-14 at 14 30 26" src="https://user-images.githubusercontent.com/2454380/173591851-cea2dc27-d38d-475f-863a-c540eab8fdc5.png">   |


