### PR TITLE
Add Groundhog Map

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,11 +12,21 @@ TODO
   - Accessible announcements of how many results for a search
 - Add RichResults
   - Dataset lol
-- Add groundhog map
 - Add location pin link to groundhog profile
+- Add Groundhog Map
+  - Add to sitemap
+  - Accessible search
+  - Add some text for screenreaders: they are probably better off with the table.
 
 DONE
 
+- Add Groundhog Map
+  - Show them all on a map
+  - Custom pins
+  - Custom tooltip
+  - Add a list
+  - Filter the list
+  - Link the page
 - Move "All ..." links on index page so people see them
 - Make sure there is always a Canadian groundhog on the index page
 - Add consensus information to groundhog predictions

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ghog-day",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ghog-day",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3-helper": "^3.1.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ghog-day",
   "description": "groundhog day website: get all groundhogs and their predictions, year by year. it's a real holiday",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "license": "MIT",
   "homepage": "https://groundhog-day.com",
   "keywords": [

--- a/public/javascripts/map.js
+++ b/public/javascripts/map.js
@@ -81,7 +81,7 @@ gh.map((g) => {
 
   marker.bindPopup(
     `<span class="leaflet-popup--triangle"></span>
-        <strong class="groundhog-name"><a href="https://groundhog-day.com/groundhogs/${g.slug}">${g.name}</a></strong> ${icon}
+        <strong class="groundhog-name"><a href="/groundhogs/${g.slug}">${g.name}</a></strong> ${icon}
         <br />
         ${g.type}
         <br />
@@ -142,7 +142,10 @@ gh.map((g) => {
 
 map.addLayer(markers)
 
-function clickItem() {
+function clickItem(e) {
+  // if clicked the "More info" button, do nothing
+  if (e.target.tagName === 'A') return
+
   const id = this.dataset.id
 
   if (iMarker >= 0) {

--- a/public/javascripts/map.js
+++ b/public/javascripts/map.js
@@ -1,13 +1,13 @@
 /* global document, L */
 
-const cards = document.querySelector('#sortable--map')
+const cardList = document.querySelector('#sortable--map ul.list')
 
 function unselectCards() {
-  cards.querySelectorAll('.card').forEach((e) => e.classList.remove('selected'))
+  cardList.querySelectorAll('.card').forEach((e) => e.classList.remove('selected'))
 }
 
 function selectCard(id) {
-  const card = cards.querySelector(`.card[data-id="${id}"]`)
+  const card = cardList.querySelector(`.card[data-id="${id}"]`)
 
   // if already selected, skip
   if (!card.classList.contains('selected')) {
@@ -163,7 +163,7 @@ function clickItem(e) {
   iMarker = id
 }
 
-var items = document.getElementById('sortable--map').querySelectorAll('.card')
+var items = cardList.querySelectorAll('.card')
 Array.prototype.forEach.call(items, (item) => {
   item.addEventListener('click', clickItem, false)
 })

--- a/public/javascripts/map.js
+++ b/public/javascripts/map.js
@@ -1,5 +1,21 @@
 /* global document, L */
 
+const cards = document.querySelector('#sortable--map')
+
+function unselectCards() {
+  cards.querySelectorAll('.card').forEach((e) => e.classList.remove('selected'))
+}
+
+function selectCard(id) {
+  const card = cards.querySelector(`.card[data-id="${id}"]`)
+
+  // if already selected, skip
+  if (!card.classList.contains('selected')) {
+    unselectCards()
+    card.classList.add('selected')
+  }
+}
+
 // https://jsfiddle.net/sxvLykkt/12/
 var gh = JSON.parse(document.getElementById('data').textContent)
 
@@ -93,9 +109,14 @@ gh.map((g) => {
     iMarker = this.options.id
   })
 
+  marker.on('popupopen', function () {
+    selectCard(this.options.id)
+  })
+
   marker.on('mouseout popupclose', function (e) {
     if (e.type !== 'popupclose' && this.isPopupOpen()) return
 
+    unselectCards()
     this.setIcon(divIcon)
     iMarker = -1
   })
@@ -124,7 +145,11 @@ map.addLayer(markers)
 function clickItem() {
   const id = this.dataset.id
 
-  if (iMarker >= 0) markerArray[iMarker].setIcon(divIcon)
+  if (iMarker >= 0) {
+    markerArray[iMarker].setIcon(divIcon)
+  }
+
+  selectCard(id)
   markerArray[id].setIcon(divIconActive)
   markerArray[id].openPopup()
 

--- a/src/routes/__tests__/index.test.js
+++ b/src/routes/__tests__/index.test.js
@@ -117,6 +117,25 @@ describe('Test ui responses', () => {
       expect($('link[rel="canonical"]').attr('href')).toMatch('/groundhog-day-2023')
     })
   })
+
+  describe('Test /map response', () => {
+    test('it should return 200', async () => {
+      const response = await request(app).get('/map')
+      expect(response.statusCode).toBe(200)
+    })
+
+    test('it should return the h1, title, meta tag, and canonical link', async () => {
+      const response = await request(app).get('/map')
+      const $ = cheerio.load(response.text)
+
+      expect($('title').text()).toEqual('Groundhog Map — GROUNDHOG-DAY.com')
+      expect($('h1').text()).toEqual('Groundhog Map')
+      expect($('meta[name="description"]').attr('content')).toEqual(
+        'Find your closest groundhog on an interactive map of North America (unless you’re from Saskatchewan).',
+      )
+      expect($('link[rel="canonical"]').attr('href')).toMatch('/map')
+    })
+  })
 })
 
 // TEST API responses

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -751,22 +751,32 @@ router.get('/groundhogs/:slug/predictions', validSlug, (req, res) => {
 /* get groundhogs and then spit them out on the map */
 router.get('/map', function (req, res) {
   const groundhogs = getGroundhogs({ oldestFirst: true })
+  const totals = {
+    all: groundhogs.length,
+    usa: 0,
+    canada: 0,
+  }
 
-  // add latestPrediction to all groundhogs
   groundhogs.map((g) => {
+    // add latestPrediction to all groundhogs
     const { shadow } = g.predictions[g.predictions.length - 1]
     g['latestPrediction'] = shadow === null ? '' : shadow ? 'winter' : 'spring'
+
+    // update totals
+    totals[g.country.toLowerCase()]++
   })
 
   // sort groundhogs by name
   groundhogs.sort((a, b) => a.name.localeCompare(b.name))
 
   res.render('pages/map', {
-    title: 'Map',
+    title: 'Groundhog Map',
     pageMeta: _getPageMeta(req, {
-      description: 'Groundhog Day map, we love it.',
+      description:
+        'Find your closest groundhog on an interactive map of North America (unless you’re from Saskatchewan).',
     }),
     groundhogs,
+    totals,
   })
 })
 

--- a/src/scss/_typography.scss
+++ b/src/scss/_typography.scss
@@ -29,7 +29,7 @@ html {
   }
 } /*18px*/
 
-body {
+body, button {
   font-family: 'Readex Pro', sans-serif;
   font-weight: 300;
   line-height: 1.75;

--- a/src/scss/components/_cards.scss
+++ b/src/scss/components/_cards.scss
@@ -24,6 +24,7 @@
 }
 
 .card {
+  text-align: left;
   border: 2px solid black;
   display: inline-block;
   position: relative;

--- a/src/scss/components/_sortable.scss
+++ b/src/scss/components/_sortable.scss
@@ -60,7 +60,8 @@ th[data-sort].sort {
   padding-right: 30px;
 }
 
-.sortable--groundhogs--search--container {
+.sortable--groundhogs--search--container,
+.sortable--map--search--container {
   padding-top: 5px;
 
   input {

--- a/src/scss/pages/_map.scss
+++ b/src/scss/pages/_map.scss
@@ -35,8 +35,8 @@
   }
 
   &:hover {
-    border-top: 2px dotted black;
-    border-bottom: 2px dotted black;
+    border-top: 2px dashed black;
+    border-bottom: 2px dashed black;
 
     &::after {
       height: 2em;
@@ -73,6 +73,17 @@
   .card {
     width: 100%;
     padding-bottom: vars.$space-md;
+    line-height: 1.75;
+
+    &.selected {
+      background: rgba(180, 180, 180, 0.15);
+      outline: 2px dotted black;
+      outline-offset: -8px;
+
+      .card--heading {
+        color: vars.$color-focus;
+      }
+    }
   }
 
   .card--heading {

--- a/src/scss/pages/_map.scss
+++ b/src/scss/pages/_map.scss
@@ -73,26 +73,42 @@
   .card {
     width: 100%;
     padding-bottom: vars.$space-md;
-    line-height: 1.75;
+    line-height: 1.65;
+
+    &:hover {
+      .card--heading {
+        color: black;
+        text-decoration: none;
+      }
+    }
 
     &.selected {
       background: rgba(180, 180, 180, 0.15);
       outline: 2px dotted black;
       outline-offset: -8px;
-
-      .card--heading {
-        color: vars.$color-focus;
-      }
     }
   }
 
   .card--heading {
     margin-bottom: vars.$space-xs;
+    text-decoration: none;
   }
 
   .card--subhead {
     margin-left: vars.$space-md;
     margin-bottom: 0;
+  }
+
+  a.link-button {
+    @include mixins.button;
+    display: inline-block;
+    margin-top: vars.$space-sm;
+    font-size: 85%;
+    background: white;
+
+    &:hover {
+      color: vars.$color-focus !important;
+    }
   }
 }
 

--- a/src/scss/pages/_map.scss
+++ b/src/scss/pages/_map.scss
@@ -5,6 +5,7 @@
   display: flex;
   gap: vars.$space-lg;
   height: 500px;
+  margin-top: vars.$space-xxl;
 }
 
 .map--list,
@@ -35,12 +36,15 @@
   }
 
   &:hover {
-    border-top: 2px dashed black;
     border-bottom: 2px dashed black;
 
     &::after {
       height: 2em;
     }
+  }
+
+  @include mixins.mobile {
+    display: none;
   }
 
   .map--list {
@@ -55,8 +59,19 @@
     }
   }
 
-  @include mixins.mobile {
-    display: none;
+  .sortable--map--search--container {
+    padding-top: 0;
+    margin-top: calc(-1 * vars.$space-sm);
+  }
+
+  .top-border {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    width: calc(100% + 1rem);
+    border-top: 2px solid black;
+    margin-top: vars.$space-lg;
+    margin-bottom: vars.$space-lg;
   }
 }
 
@@ -66,7 +81,7 @@
 }
 
 .map--list {
-  li:not(:last-of-type) {
+  li {
       margin-bottom: vars.$space-md;
   }
 

--- a/src/scss/pages/_map.scss
+++ b/src/scss/pages/_map.scss
@@ -4,28 +4,55 @@
 .map--container {
   display: flex;
   gap: vars.$space-lg;
+  height: 500px;
 }
 
 .map--list,
 .map--leaflet {
-  height: 502px;
   z-index: 1;
 }
 
-.map--list {
-  flex: 2;
-  max-width: 350px;
-  overflow: scroll;
-  padding-right: vars.$space-lg;
+.map--list--wrapper,
+.map--leaflet {
+  height: 100%;
   border-top: 2px solid transparent;
+  border-bottom: 2px solid transparent;
+}
+
+.map--list--wrapper {
+  position: relative;
+
+  &::after {
+    content: "";
+    z-index: 1;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 1em;
+    position: absolute;
+    pointer-events: none;
+    background-image: linear-gradient(to bottom, rgba(255,255,255,0), rgba(255,255,255, 1) 100%);
+  }
 
   &:hover {
     border-top: 2px dotted black;
     border-bottom: 2px dotted black;
+
+    &::after {
+      height: 2em;
+    }
   }
 
-  @include mixins.tablet-only {
+  .map--list {
     flex: 3;
+    overflow-y: scroll;
+    max-width: 360px;
+    padding-right: vars.$space-lg;
+    height: 100%;
+
+    @include mixins.tablet-only {
+      flex: 4;
+    }
   }
 
   @include mixins.mobile {
@@ -36,7 +63,6 @@
 .map--leaflet {
   flex: 3 0 200px;
   border: 2px solid black;
-  margin-top: 2px;
 }
 
 .map--list {

--- a/src/views/pages/groundhog-day-2023.njk
+++ b/src/views/pages/groundhog-day-2023.njk
@@ -16,7 +16,7 @@
     <a href="/history-of-groundhog-day">Read more about the history of Groundhog Day</a></p>
 
     <p>
-      Groundhog Day 2023 is (only) {{ daysLeft }} days away, so make sure to <a href="/groundhogs">indentify your closest groundhog</a> well in advance. Most of them livestream their predictions online, and some of them host a pancake breakfast if you can make it out in person.
+      Groundhog Day 2023 is (only) {{ daysLeft }} days away, so make sure to <a href="/map">indentify your closest groundhog</a> well in advance. Most of them livestream their predictions online, and some of them host a pancake breakfast if you can make it out in person.
     </p>
 
     <p>Unfortunately, Groundhog Day is <strong>not</strong> a statutory holiday in <a href="https://canada-holidays.ca" target="_blank" style="text-decoration: none;">Canada</a> or the USA.

--- a/src/views/pages/groundhogs.njk
+++ b/src/views/pages/groundhogs.njk
@@ -22,7 +22,9 @@
     <div class="inner-content__main">
       <div class="max-width--850">
         {% block groundhogsIntro %}
-          <p>There are <strong>{{ groundhogs | length }}</strong> weather-predicting groundhogs in <a href="/groundhogs-in-canada" aria-label="Groundhogs in Canada">Canada</a> or <a href="/groundhogs-in-usa" aria-label="Groundhogs in the USA">the USA</a> who made predictions in 2022 — including <a href="/alternative-groundhogs"><strong>{{ groundhogTypes.other }}</strong> ‘alternative’ prognosticators</a>.</p>
+          <p>
+            There are <strong>{{ groundhogs | length }}</strong> weather-predicting groundhogs in <a href="/groundhogs-in-canada" aria-label="Groundhogs in Canada">Canada</a> or <a href="/groundhogs-in-usa" aria-label="Groundhogs in the USA">the USA</a> who made predictions in 2022 — including <a href="/alternative-groundhogs"><strong>{{ groundhogTypes.other }}</strong> ‘alternative’ prognosticators</a>.
+            You can also see where they live on the <a href="/map">Groundhog Map</a>.</p>
           <p>If you don’t see your favourite prognosticator, feel free to
             <a class="link--icon" href="add-groundhog">
               {{ icon({ add: true }) }} <span>add a groundhog</span>

--- a/src/views/pages/index.njk
+++ b/src/views/pages/index.njk
@@ -74,6 +74,11 @@
       <span>All groundhogs</span> {{ icon({ right: true }) }}
     </a>
   </div>
+  <div style="margin-top: .5rem;">
+    or, check out the <a href="/map" class="link--icon link--icon--right underline">
+      <span>Groundhog Map</span> {{ icon({ right: true }) }}
+    </a>
+  </div>
 
   <br />
 

--- a/src/views/pages/map.njk
+++ b/src/views/pages/map.njk
@@ -5,11 +5,11 @@
 
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500&display=swap" rel="stylesheet">
 
-    <link rel="stylesheet" href="/javascripts/vendor/leaflet/dist/leaflet.css" />
+    <link rel="stylesheet" href="/javascripts/vendor/leaflet/dist/leaflet.css" >
     <script src="/javascripts/vendor/leaflet/dist/leaflet.js"></script>
 
-    <link rel="stylesheet" href="/javascripts/vendor/leaflet.markercluster/dist/MarkerCluster.css" />
-    <link rel="stylesheet" href="/javascripts/vendor/leaflet.markercluster/dist/MarkerCluster.Default.css" />
+    <link rel="stylesheet" href="/javascripts/vendor/leaflet.markercluster/dist/MarkerCluster.css" >
+    <link rel="stylesheet" href="/javascripts/vendor/leaflet.markercluster/dist/MarkerCluster.Default.css" >
     <script src="/javascripts/vendor/leaflet.markercluster/dist/leaflet.markercluster-src.js"></script>
 {%- endblock %}
 
@@ -18,24 +18,26 @@
 {%- endblock %}
 
 {% block content %}
-  {{ page_header({ h1: 'Map', backUrl: '/home', backText: 'Home'}) }}
+  {{ page_header({ h1: 'Groundhog Map', backUrl: '/', backText: 'Home'}) }}
 
   <p>Welcome to the map of all the groundhogs. It is mostly working.</p>
 
   <div class="map--container">
-    <div class="map--list">
-      <ul id="sortable--map">
-        {% for g in groundhogs %}
-          <li>
-            <div class="card" data-id="{{ g.id }}">
-              <div class="name card--heading h5">{{ g.name }}</div>
-              <div class="card--subhead">{{ g.type }}</div>
-              <div class="card--subhead">{{ g.city }}, {{ g.region }}</div>
-              <div class="card--subhead">{{ g.predictionsCount }} predictions since {{ g.predictions[0].year }}</div>
-            </div>
-          </li>
-        {% endfor %}
-      </ul>
+    <div class="map--list--wrapper">
+      <div class="map--list">
+        <ul id="sortable--map">
+          {% for g in groundhogs %}
+            <li>
+              <div class="card" data-id="{{ g.id }}">
+                <div class="name card--heading h5">{{ g.name }}</div>
+                <div class="card--subhead">{{ g.type }}</div>
+                <div class="card--subhead">{{ g.city }}, {{ g.region }}</div>
+                <div class="card--subhead">{{ g.predictionsCount }} predictions since {{ g.predictions[0].year }}</div>
+              </div>
+            </li>
+          {% endfor %}
+        </ul>
+      </div>
     </div>
     <div id="map" class="map--leaflet"></div>
   </div>

--- a/src/views/pages/map.njk
+++ b/src/views/pages/map.njk
@@ -20,18 +20,29 @@
 {% block content %}
   {{ page_header({ h1: 'Groundhog Map', backUrl: '/', backText: 'Home'}) }}
 
-  <p>Welcome to the map of all the groundhogs. It is mostly working.</p>
+  <div class="max-width--850">
+    <p>There are <a href="/groundhogs"><strong>{{ totals.all }}</strong> prognosticators</a> throughout North America: <a href="/groundhogs-in-usa"><strong>{{ totals.usa }}</strong> in the USA</a>, and <a href="/groundhogs-in-canada"><strong>{{ totals.canada }}</strong> in Canada</a>.
+    <br />
+    Use the map to find your nearest groundhog (unless you’re from Saskatchewan — sorry bud).</p>
+  </div>
 
   <div class="map--container">
-    <div class="map--list--wrapper">
-      <div class="map--list">
-        <ul id="sortable--map">
+    <div class="map--list--wrapper" >
+      <div class="map--list" id="sortable--map">
+        <form role="search" class="sortable--map--search--container">
+          <label for="sortable--map--search">Search for a groundhog:</label>
+          <input id="sortable--map--search" class="search" placeholder="Chuck…" type="search" />
+        </form>
+
+        <div class="top-border"></div>
+
+        <ul class="list">
           {% for g in groundhogs %}
             <li>
               <button class="card" data-id="{{ g.id }}">
                 <div class="name card--heading h5">{{ g.name }}</div>
-                <div class="card--subhead">{{ g.type }}</div>
-                <div class="card--subhead">{{ g.city }}, {{ g.region }}</div>
+                <div class="type card--subhead">{{ g.type }}</div>
+                <div class="location card--subhead">{{ g.city }}, {{ g.region }}</div>
                 <div class="card--subhead"><a class="link-button" href="/groundhogs/{{ g.slug }}">More information<span class="visually-hidden">about {{ g.name }}</span></a></div>
               </button>
             </li>
@@ -48,4 +59,11 @@
    {{ groundhogs | dump | safe }}
   </script>
   <script src="/javascripts/map.js"></script>
+
+  <script src="/javascripts/vendor/list.min.js"></script>
+  <script>
+    new List('sortable--map', {
+      valueNames: ['name', 'type', 'location']
+    });
+  </script>
 {% endblock %}

--- a/src/views/pages/map.njk
+++ b/src/views/pages/map.njk
@@ -32,7 +32,7 @@
                 <div class="name card--heading h5">{{ g.name }}</div>
                 <div class="card--subhead">{{ g.type }}</div>
                 <div class="card--subhead">{{ g.city }}, {{ g.region }}</div>
-                <div class="card--subhead">{{ g.predictionsCount }} predictions since {{ g.predictions[0].year }}</div>
+                <div class="card--subhead"><a class="link-button" href="/groundhogs/{{ g.slug }}">More information<span class="visually-hidden">about {{ g.name }}</span></a></div>
               </button>
             </li>
           {% endfor %}

--- a/src/views/pages/map.njk
+++ b/src/views/pages/map.njk
@@ -28,12 +28,12 @@
         <ul id="sortable--map">
           {% for g in groundhogs %}
             <li>
-              <div class="card" data-id="{{ g.id }}">
+              <button class="card" data-id="{{ g.id }}">
                 <div class="name card--heading h5">{{ g.name }}</div>
                 <div class="card--subhead">{{ g.type }}</div>
                 <div class="card--subhead">{{ g.city }}, {{ g.region }}</div>
                 <div class="card--subhead">{{ g.predictionsCount }} predictions since {{ g.predictions[0].year }}</div>
-              </div>
+              </button>
             </li>
           {% endfor %}
         </ul>


### PR DESCRIPTION
# Summary 

Add a Groundhog Map — a major feature — to GROUNDHOG-DAY.COM. 

This is huge: there's finally an interactive map for you to click and drag around and pan and scroll and all that fun stuff. I've gone with a 2-column interface which is how I look for ramen restaurants on google, but then if you're on a phone, the left hand list goes away.

Basically, the map is more visual, better for exploring. But if you're trying to find a specific groundhog, you can use the little search bar. The groundhogs are listed alphabetically, which seems like it's the most intuitive.

Clicking a list item will open the popup on the map and zoom to that pin. Opening a popup by clicking a pin will add the '.selected' class to the list item but it doesn't scroll the list for you automatically. Maybe it should, idk.

There are some bugs probably, but I want this out so that I can give it a bit of a run through.

## Screenshots

### When you first load the page, it looks like this

![Screenshot 2023-01-12 at 3 41 22 AM](https://user-images.githubusercontent.com/2454380/212020658-c827cef6-c790-4826-92ef-6b371d831b97.png)

### gif

![Screen Recording 2023-01-12 at 3 42 49 AM](https://user-images.githubusercontent.com/2454380/212020615-31d09b3b-0e9a-4c1c-b027-301be32ae7a1.gif)





 