### PR TITLE
Obfuscate contact emails so that they don't get web scraped

### DIFF
--- a/public/javascripts/email.js
+++ b/public/javascripts/email.js
@@ -1,0 +1,48 @@
+/* eslint-disable no-undef */
+const obfuscateEmail = (node) => {
+  // Create a new element
+  const newNode = document.createElement('a')
+
+  if (node.dataset.email) {
+    // Preserve data attributes
+    newNode.dataset.email = node.dataset.email
+    if (node.dataset.text) {
+      newNode.dataset.text = node.dataset.text
+    }
+
+    // Get email and text
+    const email = atob(node.dataset.email)
+    const text = node.dataset.text || email
+
+    // Add dummy href and obfuscated email
+    newNode.setAttribute('href', '#')
+    // idea comes from https://mauriciorobayo.github.io/react-obfuscate-email/?path=/docs/react-obfuscate-email--mail
+    newNode.innerHTML = text.replaceAll('@', '<span class="roe"></span>')
+
+    newNode.addEventListener('mouseover', unobfuscateEmail, false)
+    newNode.addEventListener('focus', unobfuscateEmail, false)
+
+    node.replaceWith(newNode)
+  }
+}
+
+function unobfuscateEmail(event) {
+  const node = event.target
+  if (node.dataset.email) {
+    // Get email and text
+    const email = atob(node.dataset.email)
+    const text = node.dataset.text || email
+
+    // Set real mailto attribute and content
+    node.setAttribute('href', 'mailto:'.concat(email))
+    node.innerText = text
+  }
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+  // Loop through all elements with "email--swap" classname
+  var nodes = document.getElementsByClassName('email--swap')
+  while (nodes.length) {
+    obfuscateEmail(nodes[0])
+  }
+})

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -118,3 +118,8 @@ img {
 .display--none {
   display: none;
 }
+
+/* for obfuscating emails. Idea comes from https://mauriciorobayo.github.io/react-obfuscate-email/?path=/docs/react-obfuscate-email--mail */
+a > span.roe::after {
+  content: "@";
+}

--- a/src/views/pages/add-groundhog.njk
+++ b/src/views/pages/add-groundhog.njk
@@ -1,5 +1,9 @@
 {% extends "layout.njk" %}
 
+{% block header_scripts -%}
+  <script src="/javascripts/email.js"></script>
+{%- endblock %}
+
 {% block body_classes -%}
   add-groundhog
 {%- endblock %}
@@ -30,6 +34,6 @@
     <p>Once you have your photo handy, it should only take 5 or so minutes to <a href="https://forms.gle/fki9UL1kwjSusbL59" target="_blank">submit your groundhog</a>.</p>
 
     <h2 class="h3" id="editing-a-groundhog">Editing a groundhog</h2>
-    <p class="mb--0">I have tried to make sure that all data on the site is accurate but mistakes do hpapen. If any information is incorrect or incomplete (eg, to add more predictions, edit a groundhog, change the photo), please email me at <a href="mailto:paul@groundhog-day.com">paul@groundhog-day.com</a> to let me know.</p>
+    <p class="mb--0">I have tried to make sure that all data on the site is accurate but mistakes do hpapen. If any information is incorrect or incomplete (eg, to add more predictions, edit a groundhog, change the photo), please email me at <span class="email--swap" data-email="cGF1bEBncm91bmRob2ctZGF5LmNvbQ==">“paul [a] groundhog-day [dot] com”</span> to let me know.</p>
   </div>
 {% endblock %}

--- a/src/views/pages/contact.njk
+++ b/src/views/pages/contact.njk
@@ -1,5 +1,9 @@
 {% extends "layout.njk" %}
 
+{% block header_scripts -%}
+  <script src="/javascripts/email.js"></script>
+{%- endblock %}
+
 {% block body_classes -%}
   contact
 {%- endblock %}
@@ -21,7 +25,7 @@
     </ul>
 
     <p>If you would like to <a href="/add-groundhog">add a new groundhog</a>, there is a dedicated page for that.</p>
-    <p>For all other inquiries / corrections, email “<a href="mailto:hello@groundhog-day.com">hello@groundhog-day.com</a>”.
+    <p>For all other inquiries / corrections, email <span class="email--swap" data-email="cGF1bEBncm91bmRob2ctZGF5LmNvbQ==">“paul [a] groundhog-day [dot] com”</span>.
 
     <br />
     <br />
@@ -30,7 +34,7 @@
     <h3 class="h5" id="contact--paul-craig">Paul Craig, Developer</h3>
 
     <p>My name is <a href="https://pcraig3.ca/" target="_blank">Paul</a> and I barely ever thought about groundhogs until <a href="https://www.canadaland.com/podcast/750-dead-willies/" target="_blank">Canadaland’s episode #750: Dead Willies</a>. Afterwards, I started Googling around and was horrified to learn that the best-case-scenario for retrieving past predictions is downloading a PDF file (an awful way to store data), with the more common case being that there is simply no central list of predictions at all.</p>
-    <p>In addition to building the site + API, I have accidentally become maybe one of the foremost Groundhog Day experts in Canada slash the world. To inquire about keynote speaking at your conference or even just to say hi, email me at “<a href="mailto:paul@groundhog-day.com">paul@groundhog-day.com</a>”.</p>
+    <p>In addition to building the site + API, I have accidentally become maybe one of the foremost Groundhog Day experts in Canada slash the world. To inquire about keynote speaking at your conference or even just to say hi, email me at <span class="email--swap" data-email="cGF1bEBncm91bmRob2ctZGF5LmNvbQ==">“paul [a] groundhog-day [dot] com”</span>.</p>
 
     <p><strong>Favourite groundhog</strong>: to be honest, I really like <a href="/groundhogs/lucy-the-lobster">Lucy the Lobster</a> from Nova Scotia.
 


### PR DESCRIPTION
The inspiration for this comes from a few places:
- https://css-tricks.com/how-to-safely-share-your-email-address-on-a-website/
- https://mauriciorobayo.github.io/react-obfuscate-email/?path=/docs/react-obfuscate-email--mail

Also, these two commits from my other repo:
- https://github.com/pcraig3/taxgpt/commit/5dffdfca87ee953311930fe2f91ce694ff76b3a1
- https://github.com/pcraig3/taxgpt/commit/5820321e0d5d661d7341433cd4b102c7c343f7d2